### PR TITLE
generalize path error handling in CheckPath

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -155,7 +155,7 @@ func MakeStaticFunc(base string) LabHandler {
 
 // CheckPath checks if the given file path exists
 func CheckPath(path string) (err error) {
-	if _, err = os.Stat(path); os.IsNotExist(err) {
+	if _, err = os.Stat(path); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
if you `touch /tmp/foo`, go test starts to fail (even though the path is still fake) because of a different error ("Not a directory") - the change generelizes the error handling an allows to handle this fringe case correctly.
