### PR TITLE
add yuinode_hash_urlstyle DOMXSS test (issue #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ In all tests, excepts where specially mentioned, the attack input is assumed to 
 
 * xss/dom/domwrite_hash?#whatever - passing the unescaped document.hash value to document.write(). PoE: /xss/dom/domwrite_hash?#in=%3Cimg%20src=foo%20onerror=alert%281246%29%3E
 
-* xss/dom/yuinode_hash?#in=xyz - passing the hash value to YUI's setHTML function.  PoE (Firefox): /xss/dom/yuinode_hash?#in=xyz">/xss/dom/yuinode_hash?#in=xyz</A> - DOM XSS using YUI (location.hash) 
+* xss/dom/yuinode_hash?#in=xyz - passing the hash value to YUI's setHTML function.  PoE (Chrome/Firefox): /xss/dom/yuinode_hash?#in=xyz">/xss/dom/yuinode_hash?#in=xyz</A> - DOM XSS using YUI (location.hash) 
+
+* xss/dom/yuinode_hash_urlstyle/#/foo/bar?in=xyz - passing the URL-style hash value to YUI's setHTML function.  PoE (Chrome/Firefox): /xss/dom/yuinode_hash_urlstyle/#/foo/bar?in=xyz">/xss/dom/yuinode_hash_urlstyle/#/foo/bar?in=xyz</A> - DOM XSS using YUI (location.hash, URL-style value) 
 
 * xss/dom/yuinode_hash_unencoded?#in=xyz - passing the unencoded hash value to YUI's setHTML function.  PoE (Firefox / Chrome): /xss/dom/yuinode_hash?#in=xyz">/xss/dom/yuinode_hash?#in=xyz</A> - DOM XSS using YUI (decoded location.hash) 
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ In all tests, excepts where specially mentioned, the attack input is assumed to 
 * xss/reflect/backslash1?in=xyz - Unicode escape sequences like \u0022 unescaped by the server to became the corresponding (dangerous) character (double quotes). 
 
 #### DOM XSS
-* xss/dom/domwrite?in=foo - passing the unescaped document.location value to document.write(), PoE: /xss/dom/domwrite?in=%3Cimg%20src=foo%20onerror=alert%28123%29%3E
+* xss/dom/domwrite?in=foo - passing the unescaped document.location value to document.write(), PoE (Firefox): /xss/dom/domwrite?in=%3Cimg%20src=foo%20onerror=alert%28123%29%3E
 
-* xss/dom/domwrite_hash?#whatever - passing the unescaped document.hash value to document.write(). PoE: /xss/dom/domwrite_hash?#in=%3Cimg%20src=foo%20onerror=alert%281246%29%3E
+* xss/dom/domwrite_hash?#whatever - passing the unescaped document.hash value to document.write(). PoE (Firefox): /xss/dom/domwrite_hash?#in=%3Cimg%20src=foo%20onerror=alert%281246%29%3E
+
+* xss/dom/domwrite_hash_urlstyle#/foo/bar?in=whatever - passing the unescaped document.hash URL-style value to document.write(). PoE (Firefox): /xss/dom/domwrite_hash_urlstyle#/foo/bar?in=%3Cimg%20src=foo%20onerror=alert%281246%29%3E
 
 * xss/dom/yuinode_hash?#in=xyz - passing the hash value to YUI's setHTML function.  PoE (Chrome/Firefox): /xss/dom/yuinode_hash?#in=xyz">/xss/dom/yuinode_hash?#in=xyz</A> - DOM XSS using YUI (location.hash) 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -84,6 +84,7 @@
 <li><B>DOM XSS</B>
   <ul><li><A href="/xss/dom/domwrite?in=abc">/xss/dom/domwrite?in=abc</A> - DOM XSS due to document.write of location.href
     <li><A href="/xss/dom/domwrite_hash?#in=xyz">/xss/dom/domwrite_hash?#in=xyz</A> - DOM XSS due to document.write of location.hash
+    <li><A href="/xss/dom/domwrite_hash_urlstyle#/foo/bar?in=xyz">/xss/dom/domwrite_hash_urlstyle#/foo/bar?in=xyz</A> - DOM XSS due to document.write of location.hash (URL-style value)
     <li><A href="/xss/dom/yuinode_hash?#in=xyz">/xss/dom/yuinode_hash?#in=xyz</A> - DOM XSS using YUI (location.hash) 
     <li><A href="/xss/dom/yuinode_hash_urlstyle#/foo/bar?in=xyz">/xss/dom/yuinode_hash_urlstyle#/foo/bar?in=xyz</A> - DOM XSS using YUI (location.hash - URL-style value)       
     <li><A href="/xss/dom/yuinode_hash_unencoded?#in=xyz">/xss/dom/yuinode_hash_unencoded?#in=xyz</A> - DOM XSS using YUI (unescaped location.hash) 

--- a/templates/index.html
+++ b/templates/index.html
@@ -85,6 +85,7 @@
   <ul><li><A href="/xss/dom/domwrite?in=abc">/xss/dom/domwrite?in=abc</A> - DOM XSS due to document.write of location.href
     <li><A href="/xss/dom/domwrite_hash?#in=xyz">/xss/dom/domwrite_hash?#in=xyz</A> - DOM XSS due to document.write of location.hash
     <li><A href="/xss/dom/yuinode_hash?#in=xyz">/xss/dom/yuinode_hash?#in=xyz</A> - DOM XSS using YUI (location.hash) 
+    <li><A href="/xss/dom/yuinode_hash_urlstyle#/foo/bar?in=xyz">/xss/dom/yuinode_hash_urlstyle#/foo/bar?in=xyz</A> - DOM XSS using YUI (location.hash - URL-style value)       
     <li><A href="/xss/dom/yuinode_hash_unencoded?#in=xyz">/xss/dom/yuinode_hash_unencoded?#in=xyz</A> - DOM XSS using YUI (unescaped location.hash) 
   </ul>
   <p>

--- a/templates/xss/dom/domwrite_hash
+++ b/templates/xss/dom/domwrite_hash
@@ -4,7 +4,7 @@
 
 DOMXSS due to passing the unescaped document.hash value to document.write(). <p>
 
-Exploit: /xss/dom/domwrite_hash#in=xyz&lt;img src=foo onerror=alert(1246)&gt; (need to reload page). <p>
+Exploit (Firefox): /xss/dom/domwrite_hash#in=xyz&lt;img src=foo onerror=alert(1246)&gt; (need to reload page). <p>
 
 
 Hello!<BR>The value of in parameter in location.hash is:  

--- a/templates/xss/dom/domwrite_hash_urlstyle
+++ b/templates/xss/dom/domwrite_hash_urlstyle
@@ -1,0 +1,13 @@
+{{ define "title" }}Webseclab - DOM XSS domwrite_hash_urlstyle{{end}}
+
+{{template "header" }}
+
+DOMXSS due to passing the unescaped document.hash value to document.write(). <p>
+
+Exploit (Firefox): /xss/dom/domwrite_hash_urlstyle#/foo/bar?in=xyz&lt;img src=foo onerror=alert(1247)&gt; (need to reload page). <p>
+
+
+Hello!<BR>The value of in parameter in location.hash (URL-style value) is:  
+<script>document.write(document.location.hash);</script>
+
+{{template "footer"}}

--- a/templates/xss/dom/yuinode_hash_unencoded
+++ b/templates/xss/dom/yuinode_hash_unencoded
@@ -4,7 +4,7 @@
 
 XSS due to the unencoded document.location.hash used in YUI Node's setHTML(). The attack works in Firefox and in the webkit browsers.<p>
 
-Exploit: /xss/dom/yuinode_hash?#in=&lt;img src=foo onerror=alert(148)&gt; (remember to reload the page!)<p>
+Exploit: /xss/dom/yuinode_hash_unencoded?#in=&lt;img src=foo onerror=alert(148)&gt; (remember to reload the page!)<p>
 
 <script src="http://yui.yahooapis.com/3.8.1/build/yui/yui.js"></script>
 Hello!<BR>The value of &quot;in&quot; hash parameter is: <div id="inparam">in placeholder</div> 

--- a/templates/xss/dom/yuinode_hash_urlstyle
+++ b/templates/xss/dom/yuinode_hash_urlstyle
@@ -4,7 +4,7 @@
 
 XSS due to the document.location.hash used in YUI Node's setHTML(). The attack works in Chrome and Firefox.<p>
 
-Exploit: /xss/dom/yuinode_hash?#in=&lt;img src=foo onerror=alert(148)&gt; (remember to reload the page!)<p>
+Exploit: /xss/dom/yuinode_hash_urlstyle#/foo/bar?in=&lt;img src=foo onerror=alert(149)&gt; (remember to reload the page!)<p>
 
 <script src="http://yui.yahooapis.com/3.8.1/build/yui/yui.js"></script>
 Hello!<BR>The value of &quot;in&quot; hash parameter is: <div id="inparam">in placeholder</div> 


### PR DESCRIPTION
yuinode_hash_urlstyle added (different URL but with the same script handling as in yuinode_hash - is it ok?), also fixed some of the documentation snippets (yuinode_has PoE works in Chrome)

PoE: `http://127.0.0.1:8080/xss/dom/yuinode_hash_urlstyle#/foo/bar?in=<img src=foo onerror=alert(149)>`

Interestingly, the PoE above works in Chrome and Opera but not in Safari - we should refresh and update the domxsswiki to have an up-to-date doc on all the browser-specific input handling diffs.
