### PR TITLE
add noindex option and basic_in_tag test

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ In all tests, excepts where specially mentioned, the attack input is assumed to 
 
 * xss/reflect/basic - echo of unfiltered input in a "normal" HTML context (not between tags, etc.). The example shows the minimal Webseclab template consisting of just {{.In}} placeholder.  PoE: /xss/reflect/basic?in=<script>alert(/HACKED/)</script>  or /xss/reflect/basic?in=<img src=foo onerror=alert(12345)>
 
+* xss/reflect/basic_in_tag - echo of unfiltered input inside of a "regular" HTML tag (<B>) PoE: /xss/reflect/basic_in_tag?in=<script>alert(/HACKED/)</script>  or /xss/reflect/basic_in_tag?in=<img src=foo onerror=alert(12345)>
+
 * xss/reflect/full1 - Javascript injection with closed quotes and a script tag echoed
 
 * xss/reflect/post1 - same as above with injection via POST "in" form field

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,8 @@
 <A href="xss/reflect/full1?in=change_me">xss/reflect/full1?in=change_me</A> - Javascript echoed (Full Javascript hack). PoE: /xss/reflect/full1?in=&lt;script&gt;alert(/XSS/)&lt;/script&gt;
         <li>
 <A href="xss/reflect/basic?in=2change">xss/reflect/basic?in=2change</A> - similar to the above, no quotes needed in the injection. Echo of unfiltered input in a "normal" HTML context (not between tags, etc.). The example shows the minimal Webseclab template consisting of just &#x7b;&#x7b;.In&#x7d;&#x7d; &quot;moustache&quot; placeholder.  PoE: /xss/reflect/basic?in=&lt;script&gt;alert(/HACKED/)&lt;/script&gt;  or /xss/reflect/basic?in=&lt;img src=foo onerror=alert(12345)&gt;
+        <li>
+<A href="xss/reflect/basic_in_tag?in=2change">xss/reflect/basic_in_tag?in=2change</A> - similar to the above but inside of an HTML tag (still no quotes needed in the injection). Echo of unfiltered input inside of a bold tag.  PoE: /xss/reflect/basic_in_tag?in=&lt;script&gt;alert(/HACKED/)&lt;/script&gt;  or /xss/reflect/basic_in_tag?in=&lt;img src=foo onerror=alert(12345)&gt;
 		<li>
 <A href="xss/reflect/post1">xss/reflect/post1</A> - Javascript echoed from the POST parameters. (Splash page: <A href="xss/reflect/post1_splash">xss/reflect/post1_splash</A>)
         <li>

--- a/templates/xss/reflect/basic_in_tag
+++ b/templates/xss/reflect/basic_in_tag
@@ -1,0 +1,2 @@
+<!-- same as basic but inside of an html tag -->
+<B>{{.In}}</B>

--- a/utils.go
+++ b/utils.go
@@ -98,13 +98,20 @@ func MakeIndexFunc(base, page string) func(http.ResponseWriter, *http.Request) {
 // and those requiring custom processing.  For standard processing, it unescapes input and prepars an instance of Indata
 // which is then passed to the template execution.  For URLs found in the map of custom processing,
 // the corresponding function is called.
-func MakeMainHandler(base string) LabHandler {
+func MakeMainHandler(base string, noindex bool) LabHandler {
 	return func(w http.ResponseWriter, r *http.Request) *LabResp {
 		// routing - handle a special case, path = "/" (=> index.html)
 		// dump, _ := httputil.DumpRequest(r, true)
 		// fmt.Printf("DEBUG request dump: %q\n", dump)
 		indexFn := MakeIndexFunc(base, "index.html")
 		if r.URL.Path == "/" || r.URL.Path == "/index.html" {
+			if noindex {
+				return &LabResp{
+					Err:  errors.New("index page is prevented with -noindex option"),
+					Code: http.StatusForbidden,
+				}
+
+			}
 			indexFn(w, r)
 			return &LabResp{Err: nil, Code: http.StatusOK}
 		}

--- a/webseclab/main.go
+++ b/webseclab/main.go
@@ -39,6 +39,7 @@ func main() {
 	}
 	base := flag.String("base", defaultBase, "base path for webseclab templates")
 	port := flag.String("http", ":8080", "port to run the webserver on")
+	noindex := flag.Bool("noindex", false, "do not serve the top index page (/ and /index.html)")
 	cleanup := flag.Bool("cleanup", false, "cleanup only (terminate existing instance and exit)")
 	flag.Parse()
 	fmt.Printf("Using %s as the template base, change it with -base command-line option (run 'webseclab -help' for usage help)\n", *base)
@@ -72,11 +73,13 @@ func main() {
 
 	fmt.Printf("Webseclab starts to listen on %s\n", *port)
 
-	http.HandleFunc("/index.html", webseclab.MakeIndexFunc(*base, "/index.html"))
+	if !*noindex {
+		http.HandleFunc("/index.html", webseclab.MakeIndexFunc(*base, "/index.html"))
+	}
 	http.HandleFunc("favicon.ico", func(w http.ResponseWriter, r *http.Request) {
 		return
 	})
-	http.Handle("/", webseclab.MakeMainHandler(*base))
+	http.Handle("/", webseclab.MakeMainHandler(*base, *noindex))
 	http.HandleFunc("/exit", webseclab.MakeExitFunc(ln))
 	http.HandleFunc("/ruok", webseclab.Ruok)
 


### PR DESCRIPTION
-noindex helps in cases where you want the scanner to  focus only on the URL you give - but the scanner is clever enough to discover other URLs from the Webseclab root ("/" or "/index.html"), as is the case with ZAP.

basic_in_tag test is a simplistic test echoing unfiltered path (including cgi parameters) inside of a &lt;B&gt; tag (just in case the scanner treats such injections differently to those outside of the tags)
