### PR TITLE
use canonical uppercase spelling of IP

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -78,9 +78,9 @@ func MakeMainHandler(noindex bool) LabHandler {
 		// be paranoid about the non-IP domains to protect cookies against XSS
 		safe := IsSafeHost(r.Host)
 		if safe == false {
-			ipurl, err := GetIpUrl(r.Host, r.URL)
+			ipurl, err := GetIPUrl(r.Host, r.URL)
 			if err != nil {
-				return &LabResp{Err: errors.New("ERROR in GetIpUrl(" + r.URL.String() + "): " + err.Error()),
+				return &LabResp{Err: errors.New("ERROR in GetIPUrl(" + r.URL.String() + "): " + err.Error()),
 					Code: http.StatusInternalServerError}
 			}
 			return &LabResp{Err: errors.New(r.Host + " - not an IP quad pair"),
@@ -134,8 +134,8 @@ func MakeIndexFunc(page string) func(http.ResponseWriter, *http.Request) {
 		var data = &InData{}
 		// for UI, find out an Ip quad-pair link if we are not on a such already
 		// this is done to protect cookies of our domain against XSS (see ip.go)
-		if IsIp(r.Host) == false {
-			iplink, err := GetIpUrl(r.Host, r.URL)
+		if IsIP(r.Host) == false {
+			iplink, err := GetIPUrl(r.Host, r.URL)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Write([]byte(`Internal Server Error`))

--- a/ip.go
+++ b/ip.go
@@ -29,29 +29,29 @@ func IsSafeHost(s string) bool {
 	if domain == "localhost" {
 		return true
 	}
-	return IsIp(s)
+	return IsIP(s)
 }
 
 // IsIP checks if the argument is a IP quad pair such as 101.02.03.04 (with optional port ex. :8080)
-func IsIp(s string) bool {
+func IsIP(s string) bool {
 	p := regexp.MustCompile(`^([\d]{1,3}\.){3}[\d]{1,3}(:\d+)?$`)
 	return p.MatchString(s)
 }
 
 // isIPUrl checks if the URL is a IP quad pair such as 101.02.03.04 (with optional port ex. :8080)
-func IsIpUrl(u *url.URL) bool {
-	return IsIp(u.Host)
+func IsIPUrl(u *url.URL) bool {
+	return IsIP(u.Host)
 }
 
-// GetIpURL returns a corresponding IP-quad URL if a FQDN is used
+// GetIPURL returns a corresponding IP-quad URL if a FQDN is used
 // if there are multiple results from LookupHost, the first one is returned
-func GetIpUrl(host string, link *url.URL) (*url.URL, error) {
-	if IsIpUrl(link) {
+func GetIPUrl(host string, link *url.URL) (*url.URL, error) {
+	if IsIPUrl(link) {
 		return link, nil
 	}
 	var domain, port string
 	if host == "" && link.Host == "" {
-		return link, errors.New("Error in GetIpUrl - no host available (neither in host param nor inside of Url). Host = " + host + ", url = " + link.String())
+		return link, errors.New("Error in GetIPUrl - no host available (neither in host param nor inside of Url). Host = " + host + ", url = " + link.String())
 	}
 	if host != "" {
 		link.Host = host
@@ -66,23 +66,23 @@ func GetIpUrl(host string, link *url.URL) (*url.URL, error) {
 	} else {
 		domain = link.Host
 	}
-	ipquads, err := net.LookupHost(domain)
+	ipQuads, err := net.LookupHost(domain)
 	if err != nil {
-		log.Printf("ERROR in IpCheck - unable to lookup the IP of %s, error: %s\n", link.Host, err)
+		log.Printf("ERROR in IPheck - unable to lookup the IP of %s, error: %s\n", link.Host, err)
 		return link, errors.New("Internal error - DNS lookup unavailable")
 	}
-	if len(ipquads) == 0 {
+	if len(ipQuads) == 0 {
 		log.Printf("ERROR in IpCheck - unable to lookup the IP of %s, error: %s\n", link.Host, err)
 		return link, errors.New("Internal error - DNS lookup unavailable")
 	}
 	if len(port) == 0 {
-		link.Host = ipquads[0]
+		link.Host = ipQuads[0]
 	} else {
 		// special case for localhost testing
-		if ipquads[0] != "::1" {
-			link.Host = ipquads[0] + ":" + port
+		if ipQuads[0] != "::1" {
+			link.Host = ipQuads[0] + ":" + port
 		} else {
-			link.Host = ipquads[1] + ":" + port
+			link.Host = ipQuads[1] + ":" + port
 		}
 	}
 	if link.Scheme == "" {

--- a/ip_test.go
+++ b/ip_test.go
@@ -26,7 +26,7 @@ func TestIsSafeHost(t *testing.T) {
 	}
 }
 
-func TestIpRegexp(t *testing.T) {
+func TestIPRegexp(t *testing.T) {
 	t.Parallel()
 	var validIP = regexp.MustCompile(`^([\d]{1,3}\.){3}[\d]{1,3}(:\d+)?$`)
 	// var validIP = regexp.MustCompile(`^[:digit]+\.[:digit]+\.[:digit]+`)
@@ -38,17 +38,17 @@ func TestIpRegexp(t *testing.T) {
 	}
 }
 
-func TestIsIp(t *testing.T) {
+func TestIsIP(t *testing.T) {
 	t.Parallel()
-	if IsIp("127.0.0.1") == false {
+	if IsIP("127.0.0.1") == false {
 		t.Errorf("Regexp did not match quad-pair IP string with no port")
 	}
-	if IsIp("www.example.com") == true {
+	if IsIP("www.example.com") == true {
 		t.Errorf("Regexp matched domain that is not a quad-pair IP")
 	}
 }
 
-func TestIsIpUrl(t *testing.T) {
+func TestIsIPUrl(t *testing.T) {
 	t.Parallel()
 	var table = []struct {
 		in   string
@@ -65,8 +65,8 @@ func TestIsIpUrl(t *testing.T) {
 			t.Errorf("Error parsing URL %s: %s\n", i.in, err)
 			return
 		}
-		if i.want != IsIpUrl(u) {
-			t.Errorf("Wrong result in IsIpURL on %s: want %t\n", u.String(), i.want)
+		if i.want != IsIPUrl(u) {
+			t.Errorf("Wrong result in IsIPURL on %s: want %t\n", u.String(), i.want)
 		}
 	}
 }
@@ -80,7 +80,7 @@ func TestIsIpUrl(t *testing.T) {
 // 		t.Errorf("Error parsing URL %s: %s\n", s, err)
 // 		return
 // 	}
-// 	ipurl, err := GetIpUrl(u.Host, u)
+// 	ipurl, err := GetIPUrl(u.Host, u)
 // 	if err != nil {
 // 		t.Errorf("Error getting IP quad URL for %s: %s\n", s, err)
 // 		return
@@ -90,7 +90,7 @@ func TestIsIpUrl(t *testing.T) {
 // 	}
 // }
 
-// func TestGetIpUrlWithPort(t *testing.T) {
+// func TestGetIPUrlWithPort(t *testing.T) {
 // 	t.Parallel()
 // 	s := "http://example.yahoo.com:8088"
 // 	want := "http://93.184.216.34:8088"
@@ -99,7 +99,7 @@ func TestIsIpUrl(t *testing.T) {
 // 		t.Errorf("Error parsing URL %s: %s\n", s, err)
 // 		return
 // 	}
-// 	ipurl, err := GetIpUrl(u.Host, u)
+// 	ipurl, err := GetIPUrl(u.Host, u)
 // 	if err != nil {
 // 		t.Errorf("Error getting IP quad URL for %s: %s\n", s, err)
 // 		return


### PR DESCRIPTION
abbreviations like "IP" should be in upper-case as in "fooIPBar" or "FooIPBar".

Similar cases in the standard library:
http://golang.org/pkg/net/#IP
http://golang.org/pkg/net/?m=all#cgoLookupIP 
