### PR TITLE
fix go vet failures

### DIFF
--- a/cmd/webseclab/main.go
+++ b/cmd/webseclab/main.go
@@ -17,11 +17,11 @@ import (
 	"github.com/yahoo/webseclab"
 )
 
-type indexHandler func(http.ResponseWriter, *http.Request) error
+// type indexHandler func(http.ResponseWriter, *http.Request) error
 
-func (fn indexHandler) ServerHTTP(w http.ResponseWriter, r *http.Request) {
-	fn(w, r)
-}
+// func (fn indexHandler) ServerHTTP(w http.ResponseWriter, r *http.Request) {
+// 	fn(w, r)
+// }
 
 const notice = `Attention: Webseclab is purposedly INSECURE software intended for testing and education.  Use it at your own risk and be careful! Hit Ctrl-C now if you don't understand the risks invovled.
 

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/yahoo/webseclab
+
+go 1.15

--- a/transform.go
+++ b/transform.go
@@ -23,14 +23,14 @@ type Transformer interface {
 
 // StringsReplacer implements Transformer using embedded strings.Replacer.
 type StringsReplacer struct {
-	strings.Replacer
+	*strings.Replacer
 }
 
 // NewStringsReplacer creates a new StringsReplacer
 // using the list of old/new strings (as in strings.NewReplacer).
 func NewStringsReplacer(oldnew ...string) *StringsReplacer {
 	r := strings.NewReplacer(oldnew...)
-	return &StringsReplacer{*r}
+	return &StringsReplacer{r}
 }
 
 // Transform implements the Transformer interface by calling
@@ -155,7 +155,7 @@ func unescapeUnicodeHelper(s string) string {
 		log.Printf("ERROR in unescapeUnicode(%s) - parsed value >= 128 %d\n", s, i)
 		return s
 	}
-	return string(i)
+	return string(rune(i))
 }
 
 func percentToSlash(s string) string {


### PR DESCRIPTION
PR fixes the current go vet failures due to copied mutex lock and deprecated conversion of integer to string (character).  It also removes unused type indexHandler and its ServerHTTP method.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
